### PR TITLE
Potential fix for code scanning alert no. 4: Missing rate limiting

### DIFF
--- a/package.json
+++ b/package.json
@@ -9,6 +9,7 @@
   "author": "",
   "license": "MIT",
   "dependencies": {
-    "express": "^5.1.0"
+    "express": "^5.1.0",
+    "express-rate-limit": "^8.0.1"
   }
 }

--- a/server.js
+++ b/server.js
@@ -1,10 +1,17 @@
 const express = require('express');
 const path = require('path');
+const rateLimit = require('express-rate-limit');
 
 const app = express();
 const PORT = process.env.PORT || 3000;
 
+// Rate limiter: max 100 requests per 15 minutes per IP
+const limiter = rateLimit({
+  windowMs: 15 * 60 * 1000, // 15 minutes
+  max: 100, // limit each IP to 100 requests per windowMs
+});
 // Serve static files for CSS, JS, and HTML assets
+app.use(limiter); // Apply rate limiting to all routes
 app.use(express.static(path.join(__dirname, '/')));
 
 // Sample FAQs data
@@ -50,7 +57,7 @@ app.get('/faq', (req, res) => {
     res.sendFile(path.join(__dirname, 'faq.html'));
 });
 
-app.get('/reporting-guidelines', (req, res) => {
+app.get('/reporting-guidelines', limiter, (req, res) => {
     res.sendFile(path.join(__dirname, 'reporting-guidelines.html'));
 });
 


### PR DESCRIPTION
Potential fix for [https://github.com/glowedjelly/homepage/security/code-scanning/4](https://github.com/glowedjelly/homepage/security/code-scanning/4)

To fix the missing rate limiting, we should apply Express rate-limiting middleware to endpoints that perform expensive operations, such as serving files from the file system. The best approach is to use the popular `express-rate-limit` package and configure a reasonable policy. We can either apply it globally (protecting all endpoints), or selectively to those routes involving file system access. A simple and effective method is:

- Install and require `express-rate-limit`.
- Create a rate limiter configuration (e.g., 100 requests per 15 minutes).
- Use `app.use(limiter);` to apply it globally, or add as middleware to the relevant route(s), e.g. `app.get('/reporting-guidelines', limiter, handler)`.
- Ensure the new dependency is installed: `express-rate-limit`.

All edits are in `server.js`. Specifically, do the following:
- Import/require `express-rate-limit` at the top.
- Define the `limiter` instance.
- Apply it either globally or specifically to the `/reporting-guidelines` route.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
