### PR TITLE
Potential fix for code scanning alert no. 9: Exposure of private files

### DIFF
--- a/server.js
+++ b/server.js
@@ -4,7 +4,7 @@ const app = express();
 const PORT = process.env.PORT || 3000;
 
 // Serve static files
-app.use(express.static(__dirname));
+app.use(express.static(path.join(__dirname, 'public')));
 
 // Fallback to index.html for SPA navigation
 app.get('*', (req, res) => {


### PR DESCRIPTION
Potential fix for [https://github.com/glowedjelly/homepage/security/code-scanning/9](https://github.com/glowedjelly/homepage/security/code-scanning/9)

To fix the issue, restrict which folder is served as static files. Instead of serving the entire source root directory (`__dirname`), only serve files from a dedicated public folder (commonly named `public`, `static`, or similar) which contains only the files meant to be available to clients (such as CSS, JS, and images). This involves:
- Creating a `public` directory at the top level of your project (if it does not already exist).
- Moving all static assets into this `public` directory.
- Changing the call from `express.static(__dirname)` to `express.static(path.join(__dirname, 'public'))` on line 7.
No other changes are needed to existing functionality.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
