### PR TITLE
Potential fix for code scanning alert no. 14: Missing rate limiting

### DIFF
--- a/server.js
+++ b/server.js
@@ -1,5 +1,6 @@
 const express = require('express');
 const path = require('path');
+const rateLimit = require('express-rate-limit');
 const app = express();
 const PORT = process.env.PORT || 3000;
 
@@ -8,7 +9,14 @@ app.use(express.static(path.join(__dirname, 'public')));
 
 // Fallback to index.html for SPA navigation
 // Catch-all handler for SPA (must be after static middleware)
-app.use((req, res) => {
+
+// Apply rate limiting to SPA fallback route
+const spaLimiter = rateLimit({
+  windowMs: 15 * 60 * 1000,  // 15 minutes
+  max: 100,                   // limit each IP to 100 requests per windowMs
+});
+
+app.use(spaLimiter, (req, res) => {
   res.sendFile(path.join(__dirname, 'index.html'));
 });
 


### PR DESCRIPTION
Potential fix for [https://github.com/glowedjelly/homepage/security/code-scanning/14](https://github.com/glowedjelly/homepage/security/code-scanning/14)

The best way to fix this problem is to use a rate-limiting middleware such as `express-rate-limit`. We need to install and import the `express-rate-limit` package and apply it to routes that involve expensive operations—in this case, the catch-all SPA route and optionally the static file serving. The minimal and most targeted fix (to minimize behavioral change) is to apply rate limiting only to the `/` catch-all handler (`app.use((req, res) => {...})`). To do this, we'll require and define a rate limiter (e.g., 100 requests per 15 minutes), and apply it as an additional middleware to the SPA route. This approach protects expensive fallback file serving without changing the functionality elsewhere.

**Steps:**
1. Install `express-rate-limit`.
2. In `server.js`, require `express-rate-limit` at the top.
3. Create a rate limiter instance.
4. Apply the rate limiter middleware before the SPA fallback handler at line 11.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
