### PR TITLE
Potential fix for code scanning alert no. 18: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/node.js.yml
+++ b/.github/workflows/node.js.yml
@@ -2,6 +2,8 @@
 # For more information see: https://docs.github.com/en/actions/automating-builds-and-tests/building-and-testing-nodejs
 
 name: Node.js CI
+permissions:
+  contents: read
 
 on:
   push:


### PR DESCRIPTION
Potential fix for [https://github.com/glowedjelly/homepage/security/code-scanning/18](https://github.com/glowedjelly/homepage/security/code-scanning/18)

The best way to fix this issue is to explicitly add a `permissions` key to the workflow or job definition, restricting the `GITHUB_TOKEN`'s permissions to `contents: read`. This will override the potentially unsafe repository default permissions and ensure the token has only read access to repository contents. Since all jobs in the workflow should likely have these restricted permissions (and the workflow is simple), place the `permissions` block at the top/root of the workflow (immediately after `name:`), affecting all jobs uniformly. No changes to functionality are required, and no additional imports or special definitions are necessary. Only the YAML workflow file needs this edit.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
