### PR TITLE
Potential fix for code scanning alert no. 17: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/npm-publish-github-packages.yml
+++ b/.github/workflows/npm-publish-github-packages.yml
@@ -10,6 +10,8 @@ on:
 jobs:
   build:
     runs-on: ubuntu-latest
+    permissions:
+      contents: read
     steps:
       - uses: actions/checkout@v4
       - uses: actions/setup-node@v4


### PR DESCRIPTION
Potential fix for [https://github.com/glowedjelly/homepage/security/code-scanning/17](https://github.com/glowedjelly/homepage/security/code-scanning/17)

To fix the problem, add a `permissions` block to the `build` job, restricting its privileges in line with the principle of least privilege. Since the `build` job only checks out code and runs tests (`npm ci`, `npm test`), it only needs to read from the repository. Therefore, add `permissions: contents: read` under the `build` job. No other permissions should be needed. This change only requires editing the .github/workflows/npm-publish-github-packages.yml file, inserting this block as a sibling to `runs-on`. No other definitions, methods, or imports are necessary.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
