### PR TITLE
Potential fix for code scanning alert no. 16: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/npm-publish.yml
+++ b/.github/workflows/npm-publish.yml
@@ -2,6 +2,8 @@
 # For more information see: https://docs.github.com/en/actions/publishing-packages/publishing-nodejs-packages
 
 name: Node.js Package
+permissions:
+  contents: read
 
 on:
   release:


### PR DESCRIPTION
Potential fix for [https://github.com/glowedjelly/homepage/security/code-scanning/16](https://github.com/glowedjelly/homepage/security/code-scanning/16)

To fix the problem, add a `permissions` block to the workflow YAML file. The ideal location is the top level (before `jobs:`), which applies it to all jobs within the workflow unless a job defines its own `permissions`. For a package publishing workflow, the minimal required permission is usually `contents: write` for publishing and possibly `packages: write` if publishing to GitHub Packages, but `contents: read` alone suffices for jobs such as installing dependencies and running tests. Therefore, set `permissions: contents: read` at the top. If any job (such as a package publishing job) requires greater privileges, add an appropriate job-level `permissions` block. In this workflow, because publishing to npm uses a secret token rather than GITHUB_TOKEN, `contents: read` at root is sufficient, unless you are publishing a GitHub release or package.

Edit the `.github/workflows/npm-publish.yml` file: insert the block immediately after the `name` property and before `on:`.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
